### PR TITLE
net.koofr.mdr % sbt-jaxws is not in Maven Central, net.koofr % sbt-jaxws is.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ Configuration
 
 Put this in your `project/plugins.sbt`:
 
-    addSbtPlugin("net.koofr.mdr" % "sbt-jaxws" % "0.1")
+    addSbtPlugin("net.koofr" % "sbt-jaxws" % "0.1")
 
 Light configuration example (in `build.sbt`):
 
-    sbtJaxWsSettings 
+    sbtJaxWsSettings
 
     SbtJaxWsKeys.wsdlFiles <+= baseDirectory(_ / "service.wsdl")
 
@@ -32,7 +32,7 @@ Full configuration example:
              SbtJaxWsKeys.targetVersion := "2.1"))
     }
 
-There is an `SbtJaxWsKeys.otherArgs` for other `wsimport` arguments -- if you use this, 
+There is an `SbtJaxWsKeys.otherArgs` for other `wsimport` arguments -- if you use this,
 please consider adding a new setting to the plug-in and sending a pull request ;-)
 
   [1]: http://jax-ws-commons.java.net/jaxws-maven-plugin/


### PR DESCRIPTION
Fixes:

[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn]  ::          UNRESOLVED DEPENDENCIES         ::
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn]  :: net.koofr.mdr#sbt-jaxws;0.1: not found
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn]
[warn]  Note: Some unresolved dependencies have extra attributes.  Check that these dependencies exist with the requested attributes.
[warn]      net.koofr.mdr:sbt-jaxws:0.1 (scalaVersion=2.10, sbtVersion=0.13)
[warn]
[warn]  Note: Unresolved dependencies path:
[warn]      net.koofr.mdr:sbt-jaxws:0.1 (scalaVersion=2.10, sbtVersion=0.13) (/Users/kfowler/projects/connectifier/project/plugins.sbt#L18-19)
[warn]        +- default:connectifier-build:0.1-SNAPSHOT (scalaVersion=2.10, sbtVersion=0.13)
sbt.ResolveException: unresolved dependency: net.koofr.mdr#sbt-jaxws;0.1: not found
